### PR TITLE
v3.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# v3.0.2
+
+- added `COLCON_IGNORE` file to ignore this package in colcon builds (for brains repo)
+- updated msgpack rpc dep to new package [rpc-msgpack](https://pypi.org/project/rpc-msgpack/)
+  that is compatible with latest versions of tornado 
+  ([msgpack-rpc-python](https://pypi.org/project/msgpack-rpc-python/) 
+  was not), which is nice for other dependencies that might need tornado (like jupyter).
+
 # v3.0.1
 
 added `COLCON_IGNORE` file to ignore this package in colcon builds (for brains repo)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 # Copyright (c) Tudor Oancea, Mattéo Berthet, EPFL Racing Team, 2022
 # This file contains pip dependencies that are not required to run the main package, but only to run the tests or other work files.
 numpy
-scipy~=1.8.0
-msgpack-rpc-python
--e git+https://github.com/EPFL-RT-Driverless/track_database.git@v3.0.1#egg=track_database
+scipy==1.8.1
+rpc-msgpack
+-e git+https://github.com/EPFL-RT-Driverless/track_database.git@v3.0.3#egg=track_database

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ with open("requirements.txt", "r") as fh:
 
 setup(
     name="fsds_client",
-    version="3.0.1",
+    version="3.0.2",
     description="Simple Python client for FSDS simulation",
     long_description=long_description,
     url="https://github.com/EPFL-RT-Driverless/fsds_client",


### PR DESCRIPTION
Enhancements for interaction with brains:
- added `COLCON_IGNORE` file to ignore this package in colcon builds (for brains repo)
- updated msgpack rpc dep to new package [rpc-msgpack](https://pypi.org/project/rpc-msgpack/)
  that is compatible with latest versions of tornado 
  ([msgpack-rpc-python](https://pypi.org/project/msgpack-rpc-python/) 
  was not), which is nice for other dependencies that might need tornado (like jupyter).